### PR TITLE
Removed wfh.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Awesome Remote Work
 - [http://www.toptal.com](http://www.toptal.com)
 - [wemake.services](https://wemake.services/)
 - [http://automattic.com/work-with-us/](http://automattic.com/work-with-us/). Made [https://wordpress.com/](Wordpress.com), has remote working culture and employees are from everywhere in the world.
-- [https://www.wfh.io/](https://www.wfh.io/), 100% remote tech-oriented job board
 - [http://jobs.remotive.io/](http://jobs.remotive.io/), weekly update with remote jobs from startups.
 - [http://remoteok.io/](http://remoteok.io/) a remote job aggregator. Job from Angel List, Stackoverflow, ...
 - [http://remotus.com/](http://remotus.com/) a fulltime jobs for developers, still under construction. Seems have a lots of startup jobs.


### PR DESCRIPTION
Wfh.io has been acquired by weworkremotely and redirect to weworkremotely. So, it's basically not needed as weworkremotely is already in the list.