### PR TITLE
Add Jobaholic to Software section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Awesome Remote Work
 - [Notion](https://www.notion.so/) - Software to write, plan, collaborate, and get organized.
 - [Taskade](https://www.taskade.com/) - Realtime organization and collaboration tool for getting things done.
 - [mob](https://mob.sh) - CLI tool for swift Git Handover.
+- [Jobaholic](https://jobaholic.app) - Chrome extension that auto-fills remote job applications across 8 ATS systems (Greenhouse, Lever, Workday, Ashby, Rippling, ADP MyJobs, Indeed, Phenom) with AI-generated cover letters per job description. Cuts a typical Workday application from 25 minutes to ~90 seconds. No LinkedIn UI automation (no account-restriction risk).
 
 ## Law
 


### PR DESCRIPTION
## What this adds

[Jobaholic](https://jobaholic.app), a Chrome extension that auto-fills remote job applications across 8 applicant tracking systems.

## Why it fits this list

Remote workers in 2026 apply to many remote postings across different company ATS systems weekly. Jobaholic cuts a typical Workday application from ~25 minutes to ~90 seconds by auto-filling the form fields and AI-generating the cover letter per job description.

Supports: Greenhouse, Lever, Workday, Ashby, Rippling, ADP MyJobs, Indeed, Phenom.

## Why this is not a LinkedIn-bot risk

Unlike some auto-apply tools (LazyApply, Sonara, Massive) that drive the LinkedIn Easy Apply UI through automation and risk LinkedIn account restrictions, Jobaholic operates on the company's own ATS form. No LinkedIn UI is touched, so no account-restriction risk per LinkedIn's published User Agreement (section 8.2).

## Pricing

Free 3-day Pro trial (no credit card), \$25/month after. There's a free tier for job search + tracking.

## Maintainer note

Happy to adjust placement (could fit in Hiring Sites too — let me know), wording, or remove if not a fit. Thanks for maintaining this list! 🙏